### PR TITLE
Lower go directive from 1.26.0 to 1.23.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module feidex
 
-go 1.26.0
+go 1.23.0
 
 require (
 	github.com/BurntSushi/toml v1.6.0


### PR DESCRIPTION
## What

Lowers the `go` directive in `go.mod` from `1.26.0` to `1.23.0`.

## Why

The README's "运行前提/必需" section states **Go 1.23+（按 `go.mod` 为准）**, but `go.mod` actually requires `1.26.0`, so users on Go 1.23–1.25 cannot build despite the documented requirement.

I checked whether `1.26.0` is actually needed:

- **No newer features are used.** Scanned for Go 1.24/1.25 additions — `os.Root`, `weak`, `runtime.AddCleanup`, `testing.B.Loop`, `omitzero` json tag, generic type aliases, the `tool` directive, `testing/synctest`, `encoding/json/v2`, `sync.WaitGroup.Go`, the `ignore` directive, flight recorder, etc. — all zero hits.
- **Builds clean at 1.23.** With the directive set to `1.23.0`, `go build ./...` and `go vet ./...` both pass with no errors.
- Dependencies are conservative and don't force a newer toolchain.

## Effect

`go 1.23.0` is a *minimum*, not a lock — Go 1.24/1.25/1.26 still build fine. This just lets the project build on the widely-available toolchains the README already promises, with no functional change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)