### PR TITLE
Support Lark (open.larksuite.com) via a feishu.domain setting

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@
 
 ## 特性亮点
 
-- **飞书接入** —— 单聊 / 群聊（可配置仅 `@bot` 响应）、回复树内会话连续性，单进程可跑多个 bot（`[[frontend]]`）
+- **飞书接入** —— 单聊 / 群聊（可配置仅 `@bot` 响应）、回复树内会话连续性，单进程可跑多个 bot（`[[frontend]]`）；也支持 Lark 国际版（`domain` 切换）
 - **双后端** —— Codex（thread/turn）与 Claude（session/conversation）并存，`/backend` 在线切换无需重启
 - **会话与队列** —— 新消息排队、回复消息 steer 到当前 turn、失败自动回退、暂存附件、auto-retry
 - **审批与表单** —— 命令 / 文件变更 / 权限审批，`request_user_input` 表单与手机友好的 quick-card
@@ -31,7 +31,7 @@
 
 - Go 1.23+（按 [go.mod](go.mod) 为准）
 - 已安装 `codex` CLI，并且 `codex app-server` 可启动
-- 一个可用的飞书应用 `app_id / app_secret`
+- 一个可用的飞书应用 `app_id / app_secret`（也支持 Lark 国际版，设 `domain = "lark"`，详见[配置参考](docs/configuration.md#区域--region飞书-vs-lark)）
 
 ### 可选
 

--- a/cmd/feidex/feishu.go
+++ b/cmd/feidex/feishu.go
@@ -39,6 +39,7 @@ func runFeishuSetup(mode config.FeishuSetupMode, args []string) int {
 	appPair := fs.String("app", "", "existing app_id:app_secret")
 	appID := fs.String("app-id", "", "existing app id")
 	appSecret := fs.String("app-secret", "", "existing app secret")
+	domain := fs.String("domain", "", "open platform domain: feishu (default) or lark")
 	timeout := fs.Int("timeout", 600, "registration timeout in seconds")
 	qrImage := fs.String("qr-image", "", "optional PNG path for saved QR code")
 	frontendID := fs.String("frontend-id", "", "add or update a [[frontend]] entry instead of top-level [feishu]")
@@ -52,6 +53,7 @@ func runFeishuSetup(mode config.FeishuSetupMode, args []string) int {
 		AppPair:    *appPair,
 		AppID:      *appID,
 		AppSecret:  *appSecret,
+		Domain:     *domain,
 		Timeout:    time.Duration(*timeout) * time.Second,
 		QRImage:    *qrImage,
 		FrontendID: *frontendID,
@@ -65,7 +67,7 @@ func runFeishuSetup(mode config.FeishuSetupMode, args []string) int {
 
 func printFeishuUsage() {
 	fmt.Println(`Usage:
-  feidex feishu setup [--config config.toml] [--frontend-id id] [--backend codex|claude]
+  feidex feishu setup [--config config.toml] [--frontend-id id] [--backend codex|claude] [--domain feishu|lark]
   feidex feishu new [--config config.toml] [--frontend-id id] [--backend codex|claude]
-  feidex feishu bind --app app_id:app_secret [--config config.toml] [--frontend-id id]`)
+  feidex feishu bind --app app_id:app_secret [--config config.toml] [--frontend-id id] [--domain feishu|lark]`)
 }

--- a/config.example.toml
+++ b/config.example.toml
@@ -9,6 +9,9 @@ level = "info"
 # Leave unset to get an interactive backend-chooser card on first message.
 [feishu]
 # backend = ""
+# domain selects the Open Platform endpoint:
+#   "feishu" (default) -> open.feishu.cn   |   "lark" -> open.larksuite.com
+# domain = "feishu"
 app_id = "cli_xxx"
 app_secret = "sec_xxx"
 allow_from = []

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -121,6 +121,22 @@ feidex feishu bind --app app_id:app_secret --domain lark
 - `feidex feishu new` 的二维码自助注册流程只对 `feishu` 域名可用。Lark 国际版请在 [open.larksuite.com](https://open.larksuite.com) 后台创建应用，再用 `feishu bind --domain lark` 绑定凭据。
 - `domain` 只影响 Open Platform 接口域名，不改变任何会话 / 命令 / 卡片行为。
 
+### 创建应用与机器人（官方文档）
+
+| 区域 | 开发者后台 | 创建机器人指南 |
+| --- | --- | --- |
+| 飞书 | [open.feishu.cn/app](https://open.feishu.cn/app) | [5 分钟开发机器人](https://open.feishu.cn/document/home/develop-a-bot-in-5-minutes/introduction) |
+| Lark | [open.larksuite.com/app](https://open.larksuite.com/app) | [Develop a bot in 5 minutes](https://open.larksuite.com/document/home/develop-a-bot-in-5-minutes/introduction) |
+
+接入 Feidex 时，在后台需要：
+
+- 启用 **机器人 / Bot** 能力（卡片菜单/审批需要 **消息卡片**）
+- **事件与回调**订阅方式选 **长连接 / persistent connection**（无需公网回调 URL），并订阅 `im.message.receive_v1`、卡片回调 `card.action.trigger`
+- **权限 scopes** 至少 `im:message`、`im:message:send_as_bot`；用附件/下载再加 `im:resource`、`drive:drive`
+- 配置改动后**创建并发布版本**才生效
+
+> 提示：消息相关 scope 不全时，长连接能建立但**收不到消息事件**（连得上却不回复）。若 bot 不响应，优先核对上面的消息权限并重新发布。
+
 ## `[codex]`
 
 - `command`

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -73,7 +73,10 @@ Feidex 会把这些状态写进去：
 ## `[feishu]`
 
 - `app_id` / `app_secret`
-  - 飞书应用凭据
+  - 飞书应用凭据（Lark 国际版同样适用）
+- `domain`
+  - Open Platform 区域，决定接口域名：`feishu`（默认，`open.feishu.cn`）或 `lark`（国际版，`open.larksuite.com`）
+  - 默认即飞书，无需设置；仅 Lark 国际版需要。详见下文 [区域 / Region（飞书 vs Lark）](#区域--region飞书-vs-lark)
 - `allow_from`
   - 允许的用户列表；空表示不限制
 - `debug_allow_from`
@@ -88,6 +91,35 @@ Feidex 会把这些状态写进去：
   - 群聊是否在线程内回复
 - `quiet`
   - Quiet 模式默认值，默认 `progress`
+
+## 区域 / Region（飞书 vs Lark）
+
+飞书（国内版）与 Lark（国际版）共用同一套 SDK，只是 Open Platform 域名不同。Feidex 用 `[feishu].domain` 切换：
+
+| `domain` | Open Platform 域名 | 适用 |
+| --- | --- | --- |
+| `feishu`（默认） | `open.feishu.cn` | 飞书（国内版） |
+| `lark` | `open.larksuite.com` | Lark（国际版） |
+
+```toml
+[feishu]
+domain = "lark"
+app_id = "cli_xxx"
+app_secret = "sec_xxx"
+```
+
+多前端时，`domain` 同样可写在每个 `[[frontend]]` 下，互不影响。
+
+绑定 Lark 应用：
+
+```bash
+feidex feishu bind --app app_id:app_secret --domain lark
+```
+
+注意：
+
+- `feidex feishu new` 的二维码自助注册流程只对 `feishu` 域名可用。Lark 国际版请在 [open.larksuite.com](https://open.larksuite.com) 后台创建应用，再用 `feishu bind --domain lark` 绑定凭据。
+- `domain` 只影响 Open Platform 接口域名，不改变任何会话 / 命令 / 卡片行为。
 
 ## `[codex]`
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -35,6 +35,7 @@ type FeishuConfig struct {
 	AutoRetry           bool      `toml:"codex_auto_retry"`
 	AppID               string    `toml:"app_id"`
 	AppSecret           string    `toml:"app_secret"`
+	Domain              string    `toml:"domain"`
 	AllowFrom           []string  `toml:"allow_from"`
 	DebugAllowFrom      []string  `toml:"debug_allow_from"`
 	GroupAtOnly         bool      `toml:"group_at_only"`
@@ -100,6 +101,25 @@ const (
 	RuntimeBackendClaude = "claude"
 	DefaultFrontendID    = "default"
 )
+
+// Feishu/Lark Open Platform domains. The Go SDK is shared between the two
+// products; only the Open Platform base URL differs.
+const (
+	FeishuDomainFeishu = "feishu"
+	FeishuDomainLark   = "lark"
+
+	feishuOpenBaseURL = "https://open.feishu.cn"
+	larkOpenBaseURL   = "https://open.larksuite.com"
+)
+
+// OpenBaseURL returns the Open Platform base URL for the configured domain.
+// Defaults to Feishu (open.feishu.cn) when domain is unset.
+func (c FeishuConfig) OpenBaseURL() string {
+	if c.Domain == FeishuDomainLark {
+		return larkOpenBaseURL
+	}
+	return feishuOpenBaseURL
+}
 
 func Default() *Config {
 	return &Config{
@@ -299,12 +319,30 @@ func normalizeFeishuConfig(cfg *FeishuConfig) error {
 	default:
 		return fmt.Errorf("unsupported feishu.backend %q; must be unset, %q, or %q", cfg.Backend, RuntimeBackendCodex, RuntimeBackendClaude)
 	}
+	domain, err := normalizeFeishuDomain(cfg.Domain)
+	if err != nil {
+		return err
+	}
+	cfg.Domain = domain
 	quietMode, err := ParseQuietMode(cfg.Quiet)
 	if err != nil {
 		quietMode = QuietModeNormal
 	}
 	cfg.Quiet = quietMode
 	return nil
+}
+
+// normalizeFeishuDomain canonicalizes a domain value to FeishuDomainFeishu or
+// FeishuDomainLark. An empty value defaults to Feishu.
+func normalizeFeishuDomain(domain string) (string, error) {
+	switch strings.ToLower(strings.TrimSpace(domain)) {
+	case "", FeishuDomainFeishu:
+		return FeishuDomainFeishu, nil
+	case FeishuDomainLark:
+		return FeishuDomainLark, nil
+	default:
+		return "", fmt.Errorf("unsupported feishu.domain %q; must be unset, %q, or %q", domain, FeishuDomainFeishu, FeishuDomainLark)
+	}
 }
 
 func firstNonEmptyString(values ...string) string {

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -7,6 +7,40 @@ import (
 	"testing"
 )
 
+func TestFeishuDomainNormalizationAndBaseURL(t *testing.T) {
+	cases := []struct {
+		input   string
+		want    string
+		baseURL string
+		wantErr bool
+	}{
+		{input: "", want: FeishuDomainFeishu, baseURL: "https://open.feishu.cn"},
+		{input: "feishu", want: FeishuDomainFeishu, baseURL: "https://open.feishu.cn"},
+		{input: "  LARK ", want: FeishuDomainLark, baseURL: "https://open.larksuite.com"},
+		{input: "Feishu", want: FeishuDomainFeishu, baseURL: "https://open.feishu.cn"},
+		{input: "slack", wantErr: true},
+	}
+	for _, tc := range cases {
+		cfg := FeishuConfig{Domain: tc.input}
+		err := normalizeFeishuConfig(&cfg)
+		if tc.wantErr {
+			if err == nil {
+				t.Fatalf("normalizeFeishuConfig(domain=%q) expected error", tc.input)
+			}
+			continue
+		}
+		if err != nil {
+			t.Fatalf("normalizeFeishuConfig(domain=%q) error = %v", tc.input, err)
+		}
+		if cfg.Domain != tc.want {
+			t.Fatalf("domain %q normalized to %q, want %q", tc.input, cfg.Domain, tc.want)
+		}
+		if got := cfg.OpenBaseURL(); got != tc.baseURL {
+			t.Fatalf("domain %q OpenBaseURL() = %q, want %q", tc.input, got, tc.baseURL)
+		}
+	}
+}
+
 func TestNormalizeLogLevel(t *testing.T) {
 	cases := []struct {
 		input string

--- a/internal/config/feishu_setup.go
+++ b/internal/config/feishu_setup.go
@@ -17,10 +17,7 @@ import (
 	"rsc.io/qr"
 )
 
-const (
-	accountsBaseURL = "https://accounts.feishu.cn"
-	openBaseURL     = "https://open.feishu.cn"
-)
+const accountsBaseURL = "https://accounts.feishu.cn"
 
 type FeishuSetupMode string
 
@@ -36,6 +33,7 @@ type FeishuSetupOptions struct {
 	AppPair    string
 	AppID      string
 	AppSecret  string
+	Domain     string
 	Timeout    time.Duration
 	QRImage    string
 	FrontendID string
@@ -92,6 +90,11 @@ func SetupFeishu(mode FeishuSetupMode, opts FeishuSetupOptions) error {
 		}
 	}
 
+	domain, err := normalizeFeishuDomain(opts.Domain)
+	if err != nil {
+		return err
+	}
+
 	appID := strings.TrimSpace(opts.AppID)
 	appSecret := strings.TrimSpace(opts.AppSecret)
 	if strings.TrimSpace(opts.AppPair) != "" {
@@ -106,12 +109,15 @@ func SetupFeishu(mode FeishuSetupMode, opts FeishuSetupOptions) error {
 		if appID == "" || appSecret == "" {
 			return errors.New("bind mode requires --app or --app-id/--app-secret")
 		}
-		if err := validateFeishuCredentials(appID, appSecret); err != nil {
+		if err := validateFeishuCredentials(appID, appSecret, domain); err != nil {
 			return err
 		}
 	case FeishuSetupNew:
 		if appID != "" || appSecret != "" {
 			return errors.New("new mode does not accept existing credentials")
+		}
+		if domain == FeishuDomainLark {
+			return errors.New("new mode (QR self-registration) is only supported for the feishu domain; for lark, create the app at open.larksuite.com and use `feishu bind --domain lark`")
 		}
 		appID, appSecret, err = runRegistrationFlow(opts.Timeout, opts.QRImage)
 		if err != nil {
@@ -123,12 +129,13 @@ func SetupFeishu(mode FeishuSetupMode, opts FeishuSetupOptions) error {
 
 	frontendID := strings.TrimSpace(opts.FrontendID)
 	if frontendID != "" {
-		if err := saveToFrontend(cfg, frontendID, appID, appSecret, strings.TrimSpace(opts.Backend)); err != nil {
+		if err := saveToFrontend(cfg, frontendID, appID, appSecret, domain, strings.TrimSpace(opts.Backend)); err != nil {
 			return err
 		}
 	} else {
 		cfg.Feishu.AppID = appID
 		cfg.Feishu.AppSecret = appSecret
+		cfg.Feishu.Domain = domain
 	}
 	if err := Save(cfgPath, cfg); err != nil {
 		return err
@@ -142,7 +149,7 @@ func SetupFeishu(mode FeishuSetupMode, opts FeishuSetupOptions) error {
 	return nil
 }
 
-func saveToFrontend(cfg *Config, id, appID, appSecret, backend string) error {
+func saveToFrontend(cfg *Config, id, appID, appSecret, domain, backend string) error {
 	if strings.Contains(id, ":") {
 		return fmt.Errorf("frontend id %q must not contain ':'", id)
 	}
@@ -156,6 +163,7 @@ func saveToFrontend(cfg *Config, id, appID, appSecret, backend string) error {
 	if idx >= 0 {
 		cfg.Frontends[idx].AppID = appID
 		cfg.Frontends[idx].AppSecret = appSecret
+		cfg.Frontends[idx].Domain = domain
 		if backend != "" {
 			cfg.Frontends[idx].Backend = backend
 		}
@@ -173,6 +181,7 @@ func saveToFrontend(cfg *Config, id, appID, appSecret, backend string) error {
 	fc := FrontendConfig{ID: id}
 	fc.AppID = appID
 	fc.AppSecret = appSecret
+	fc.Domain = domain
 	if backend != "" {
 		fc.Backend = backend
 	}
@@ -196,12 +205,16 @@ func loadOrCreateConfig(path, workspaceID string) (*Config, error) {
 	return cfg, Save(path, cfg)
 }
 
-func validateFeishuCredentials(appID, appSecret string) error {
+func validateFeishuCredentials(appID, appSecret, domain string) error {
+	base := feishuOpenBaseURL
+	if domain == FeishuDomainLark {
+		base = larkOpenBaseURL
+	}
 	payload, _ := json.Marshal(map[string]string{
 		"app_id":     appID,
 		"app_secret": appSecret,
 	})
-	req, err := http.NewRequest(http.MethodPost, openBaseURL+"/open-apis/auth/v3/tenant_access_token/internal", bytes.NewReader(payload))
+	req, err := http.NewRequest(http.MethodPost, base+"/open-apis/auth/v3/tenant_access_token/internal", bytes.NewReader(payload))
 	if err != nil {
 		return err
 	}

--- a/internal/config/feishu_setup_test.go
+++ b/internal/config/feishu_setup_test.go
@@ -116,14 +116,26 @@ func TestValidateFeishuCredentialsAndRegistrationCall(t *testing.T) {
 		}
 		return testHTTPResponse(`{"ok":true}`), nil
 	}))
-	if err := validateFeishuCredentials("app", "secret"); err != nil {
+	if err := validateFeishuCredentials("app", "secret", FeishuDomainFeishu); err != nil {
 		t.Fatalf("validateFeishuCredentials(success) error = %v", err)
+	}
+
+	var larkHost string
+	withDefaultTransport(t, setupRoundTripper(func(req *http.Request) (*http.Response, error) {
+		larkHost = req.URL.Host
+		return testHTTPResponse(`{"code":0,"tenant_access_token":"token"}`), nil
+	}))
+	if err := validateFeishuCredentials("app", "secret", FeishuDomainLark); err != nil {
+		t.Fatalf("validateFeishuCredentials(lark) error = %v", err)
+	}
+	if larkHost != "open.larksuite.com" {
+		t.Fatalf("lark domain hit host %q, want open.larksuite.com", larkHost)
 	}
 
 	withDefaultTransport(t, setupRoundTripper(func(req *http.Request) (*http.Response, error) {
 		return testHTTPResponse(`{"code":999,"msg":"bad creds"}`), nil
 	}))
-	if err := validateFeishuCredentials("app", "secret"); err == nil {
+	if err := validateFeishuCredentials("app", "secret", FeishuDomainFeishu); err == nil {
 		t.Fatal("expected invalid credentials to fail")
 	}
 

--- a/internal/feishu/adapter.go
+++ b/internal/feishu/adapter.go
@@ -296,7 +296,7 @@ func (a *Adapter) fetchWSEndpointURL(ctx context.Context) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	req, err := http.NewRequestWithContext(ctx, http.MethodPost, lark.FeishuBaseUrl+larkws.GenEndpointUri, bytes.NewBuffer(body))
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, a.cfg.OpenBaseURL()+larkws.GenEndpointUri, bytes.NewBuffer(body))
 	if err != nil {
 		return "", err
 	}
@@ -1846,7 +1846,7 @@ func (a *Adapter) fetchBotOpenID() string {
 		"app_id":     a.cfg.AppID,
 		"app_secret": a.cfg.AppSecret,
 	})
-	req, err := http.NewRequestWithContext(ctx, http.MethodPost, "https://open.feishu.cn/open-apis/auth/v3/tenant_access_token/internal", strings.NewReader(string(body)))
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, a.cfg.OpenBaseURL()+"/open-apis/auth/v3/tenant_access_token/internal", strings.NewReader(string(body)))
 	if err != nil {
 		return ""
 	}
@@ -1863,7 +1863,7 @@ func (a *Adapter) fetchBotOpenID() string {
 	if err := json.NewDecoder(resp.Body).Decode(&tokenResp); err != nil || tokenResp.Code != 0 || tokenResp.TenantAccessToken == "" {
 		return ""
 	}
-	infoReq, err := http.NewRequestWithContext(ctx, http.MethodGet, "https://open.feishu.cn/open-apis/bot/v3/info", nil)
+	infoReq, err := http.NewRequestWithContext(ctx, http.MethodGet, a.cfg.OpenBaseURL()+"/open-apis/bot/v3/info", nil)
 	if err != nil {
 		return ""
 	}

--- a/internal/feishu/token_refresh.go
+++ b/internal/feishu/token_refresh.go
@@ -91,7 +91,10 @@ func (c *resettableLarkTokenCache) clearTenantAccessTokens(appID string) int {
 }
 
 func newFeishuLarkClient(cfg config.FeishuConfig) *lark.Client {
-	return lark.NewClient(cfg.AppID, cfg.AppSecret, lark.WithTokenCache(sharedFeishuTokenCache))
+	return lark.NewClient(cfg.AppID, cfg.AppSecret,
+		lark.WithTokenCache(sharedFeishuTokenCache),
+		lark.WithOpenBaseUrl(cfg.OpenBaseURL()),
+	)
 }
 
 func (a *Adapter) currentClient() *lark.Client {


### PR DESCRIPTION
## What

Adds support for **Lark international** (`open.larksuite.com`) alongside Feishu, via a new `[feishu].domain` option.

Previously Feidex was hardwired to `open.feishu.cn`:
- the lark SDK client used the default Feishu base URL,
- the websocket `gen_endpoint` call used `lark.FeishuBaseUrl`,
- `tenant_access_token` and `bot/v3/info` calls hardcoded `https://open.feishu.cn`.

So Lark tenants couldn't be used at all, even though the underlying SDK is shared between the two products.

## Change

- **config**: new `Domain` field on `FeishuConfig` (`"feishu"` default, or `"lark"`), normalization (defaults to feishu, rejects unknown values), and a `FeishuConfig.OpenBaseURL()` helper.
- **feishu adapter**: lark client sets `WithOpenBaseUrl(cfg.OpenBaseURL())`; the websocket endpoint and bot-info calls route through `OpenBaseURL()` instead of the hardcoded host.
- **setup / CLI**: `feishu bind --domain lark` validates credentials against the correct host and persists the domain. QR self-registration (`feishu new`) stays feishu-only, with a message pointing Lark users to create the app at open.larksuite.com and use `bind`.
- **docs**: `configuration.md` gains a 「区域 / Region（飞书 vs Lark）」 section; `config.example.toml` shows the `domain` field; README notes Lark support (feishu-first framing).

## Compatibility

Default is unchanged — `domain` defaults to `feishu`, existing `config.toml` files keep working with zero edits. A unit test pins "empty → feishu → open.feishu.cn" to guard against regressions.

## Testing

- Unit tests for domain normalization + `OpenBaseURL()` and domain-aware credential validation (asserts the lark path hits `open.larksuite.com`). `go test -race ./internal/config` and `./internal/feishu` pass.
- **Verified end-to-end against a real Lark tenant**: `domain="lark"` correctly routes to `open.larksuite.com`, credentials authenticate, the websocket long connection establishes, and a single-chat message round-trips through the Claude backend.

🤖 Generated with [Claude Code](https://claude.com/claude-code)