### PR TITLE
Windows support: release binaries, CI cross-build, and install.ps1

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -30,6 +30,11 @@ jobs:
       - name: Test
         run: go test -v ./...
 
+      - name: Cross-build (Windows)
+        run: |
+          GOOS=windows GOARCH=amd64 go build ./...
+          GOOS=windows GOARCH=arm64 go build ./...
+
   release-dev-linux:
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'
     needs: ci
@@ -66,7 +71,9 @@ jobs:
             "linux:amd64:feidex-linux-amd64" \
             "linux:arm64:feidex-linux-aarch64" \
             "darwin:amd64:feidex-darwin-amd64" \
-            "darwin:arm64:feidex-darwin-arm64"; do
+            "darwin:arm64:feidex-darwin-arm64" \
+            "windows:amd64:feidex-windows-amd64.exe" \
+            "windows:arm64:feidex-windows-arm64.exe"; do
             IFS=':' read -r GOOS GOARCH ASSET <<<"${target}"
             CGO_ENABLED=0 GOOS="${GOOS}" GOARCH="${GOARCH}" \
               go build -trimpath -ldflags="-s -w -X feidex/internal/buildinfo.Version=${VERSION}" \
@@ -80,6 +87,8 @@ jobs:
           tar -C dist -czf dist/feidex-linux-aarch64.tar.gz feidex-linux-aarch64
           tar -C dist -czf dist/feidex-darwin-amd64.tar.gz feidex-darwin-amd64
           tar -C dist -czf dist/feidex-darwin-arm64.tar.gz feidex-darwin-arm64
+          (cd dist && zip -q feidex-windows-amd64.zip feidex-windows-amd64.exe)
+          (cd dist && zip -q feidex-windows-arm64.zip feidex-windows-arm64.exe)
           sha256sum \
             dist/feidex-linux-amd64 \
             dist/feidex-linux-amd64.tar.gz \
@@ -89,6 +98,10 @@ jobs:
             dist/feidex-darwin-amd64.tar.gz \
             dist/feidex-darwin-arm64 \
             dist/feidex-darwin-arm64.tar.gz \
+            dist/feidex-windows-amd64.exe \
+            dist/feidex-windows-amd64.zip \
+            dist/feidex-windows-arm64.exe \
+            dist/feidex-windows-arm64.zip \
             > dist/sha256sums.txt
 
       - name: Move dev-latest tag
@@ -121,6 +134,10 @@ jobs:
             dist/feidex-darwin-amd64.tar.gz
             dist/feidex-darwin-arm64
             dist/feidex-darwin-arm64.tar.gz
+            dist/feidex-windows-amd64.exe
+            dist/feidex-windows-amd64.zip
+            dist/feidex-windows-arm64.exe
+            dist/feidex-windows-arm64.zip
             dist/sha256sums.txt
 
   release-linux:
@@ -146,7 +163,9 @@ jobs:
             "linux:amd64:feidex-linux-amd64" \
             "linux:arm64:feidex-linux-aarch64" \
             "darwin:amd64:feidex-darwin-amd64" \
-            "darwin:arm64:feidex-darwin-arm64"; do
+            "darwin:arm64:feidex-darwin-arm64" \
+            "windows:amd64:feidex-windows-amd64.exe" \
+            "windows:arm64:feidex-windows-arm64.exe"; do
             IFS=':' read -r GOOS GOARCH ASSET <<<"${target}"
             CGO_ENABLED=0 GOOS="${GOOS}" GOARCH="${GOARCH}" \
               go build -trimpath -ldflags="-s -w -X feidex/internal/buildinfo.Version=${VERSION}" \
@@ -160,6 +179,8 @@ jobs:
           tar -C dist -czf dist/feidex-linux-aarch64.tar.gz feidex-linux-aarch64
           tar -C dist -czf dist/feidex-darwin-amd64.tar.gz feidex-darwin-amd64
           tar -C dist -czf dist/feidex-darwin-arm64.tar.gz feidex-darwin-arm64
+          (cd dist && zip -q feidex-windows-amd64.zip feidex-windows-amd64.exe)
+          (cd dist && zip -q feidex-windows-arm64.zip feidex-windows-arm64.exe)
           sha256sum \
             dist/feidex-linux-amd64 \
             dist/feidex-linux-amd64.tar.gz \
@@ -169,6 +190,10 @@ jobs:
             dist/feidex-darwin-amd64.tar.gz \
             dist/feidex-darwin-arm64 \
             dist/feidex-darwin-arm64.tar.gz \
+            dist/feidex-windows-amd64.exe \
+            dist/feidex-windows-amd64.zip \
+            dist/feidex-windows-arm64.exe \
+            dist/feidex-windows-arm64.zip \
             > dist/sha256sums.txt
 
       - name: Publish GitHub release assets
@@ -186,4 +211,8 @@ jobs:
             dist/feidex-darwin-amd64.tar.gz
             dist/feidex-darwin-arm64
             dist/feidex-darwin-arm64.tar.gz
+            dist/feidex-windows-amd64.exe
+            dist/feidex-windows-amd64.zip
+            dist/feidex-windows-arm64.exe
+            dist/feidex-windows-arm64.zip
             dist/sha256sums.txt

--- a/README.md
+++ b/README.md
@@ -34,14 +34,16 @@
 
 ### 可选
 
-- **Go 1.23+**（按 [go.mod](go.mod) 为准）：仅[从源码构建](#从源码构建)时需要；用[一键安装](#一键安装推荐linux--macos)下载预编译二进制则不需要
+- **Go 1.23+**（按 [go.mod](go.mod) 为准）：仅[从源码构建](#从源码构建)时需要；用[一键安装](#一键安装推荐)下载预编译二进制则不需要
 - Linux + systemd 用户服务：如果你希望 Feidex 长驻后台并支持自升级，推荐使用 [daemon 模式](docs/operations.md#daemon-模式)
 
 ## 快速开始
 
-### 一键安装（推荐，Linux / macOS）
+### 一键安装（推荐）
 
-下载对应平台的 release 二进制、校验 SHA-256、装到 PATH，无需 Go 工具链：
+下载对应平台的 release 二进制、校验 SHA-256、装到 PATH，无需 Go 工具链。
+
+#### Linux / macOS
 
 ```bash
 curl -fsSL https://raw.githubusercontent.com/yuhuan417/feidex/main/install.sh | bash
@@ -52,6 +54,14 @@ curl -fsSL https://raw.githubusercontent.com/yuhuan417/feidex/main/install.sh | 
 curl -fsSL https://raw.githubusercontent.com/yuhuan417/feidex/main/install.sh | bash -s -- --dev
 curl -fsSL https://raw.githubusercontent.com/yuhuan417/feidex/main/install.sh | bash -s -- --version v0.222.0 --bin-dir /usr/local/bin
 ```
+
+#### Windows（PowerShell）
+
+```powershell
+irm https://raw.githubusercontent.com/yuhuan417/feidex/main/install.ps1 | iex
+```
+
+> Windows 上 `feidex serve` 可直接运行；systemd daemon 与 `/upgrade` 自升级为 Linux 专属。
 
 安装选项见 [安装脚本](docs/operations.md#一键安装脚本)。
 

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -6,37 +6,45 @@
 
 ## 一键安装脚本
 
-`install.sh` 从 GitHub Release 下载对应平台的二进制、校验 `sha256sums.txt`、装到 PATH，无需 Go 工具链。仅支持 Linux / macOS（amd64 / arm64）。
+从 GitHub Release 下载对应平台的二进制、校验 `sha256sums.txt`、装到 PATH，无需 Go 工具链。支持 Linux / macOS / Windows（amd64 / arm64）。
+
+Linux / macOS（`install.sh`）：
 
 ```bash
 curl -fsSL https://raw.githubusercontent.com/yuhuan417/feidex/main/install.sh | bash
 ```
 
-选项（写在 `| bash -s --` 之后）：
+Windows（`install.ps1`，PowerShell）：
 
-- `--version <vX.Y.Z>`
+```powershell
+irm https://raw.githubusercontent.com/yuhuan417/feidex/main/install.ps1 | iex
+```
+
+选项（`install.sh` 写在 `| bash -s --` 之后；`install.ps1` 用 PowerShell 参数 `-Version` / `-Dev` / `-BinDir` / `-Repo` / `-NoModifyPath`）：
+
+- `--version <vX.Y.Z>` / `-Version`
   - 安装指定版本（默认最新 release）
-- `--dev`
+- `--dev` / `-Dev`
   - 安装最新开发版（`dev-latest` prerelease）
-- `--bin-dir <dir>`
-  - 安装目录（默认 `~/.local/bin`）
-- `--repo <owner/name>`
+- `--bin-dir <dir>` / `-BinDir`
+  - 安装目录（`install.sh` 默认 `~/.local/bin`；`install.ps1` 默认 `%LOCALAPPDATA%\Programs\feidex`）
+- `--repo <owner/name>` / `-Repo`
   - 指定来源仓库（默认 `yuhuan417/feidex`）
-- `--no-modify-path`
-  - 不自动把安装目录写进 shell profile
+- `--no-modify-path` / `-NoModifyPath`
+  - 不自动把安装目录写进 PATH（shell profile / 用户 PATH）
 - `-h` / `--help`
-  - 显示帮助
+  - 显示帮助（仅 `install.sh`）
 
 环境变量等价：`FEIDEX_VERSION`、`FEIDEX_REPO`、`FEIDEX_BIN_DIR`。
 
 行为：
 
-- 按 `uname` 识别 OS/架构，自动选 `feidex-linux-amd64` / `feidex-linux-aarch64` / `feidex-darwin-amd64` / `feidex-darwin-arm64`
+- 识别 OS/架构，自动选对应资产：`feidex-linux-amd64` / `feidex-linux-aarch64` / `feidex-darwin-amd64` / `feidex-darwin-arm64` / `feidex-windows-amd64.exe` / `feidex-windows-arm64.exe`
 - 强制校验 SHA-256（与 release 的 `sha256sums.txt` 比对，不一致即中止）
 - 原子替换（可重复执行以升级；二进制正被占用时也安全）
-- 安装目录不在 PATH 时，提示或写入 shell profile（`--no-modify-path` 可关闭）
+- 安装目录不在 PATH 时，提示或写入 PATH（`--no-modify-path` / `-NoModifyPath` 可关闭）
 
-> Windows 或离线环境请用 [手动安装 release 包](#release-资产) 或[从源码构建](../README.md#从源码构建)。安装后日常升级也可用 `/upgrade`（见[自动升级](#自动升级)）。
+> Windows 上 `feidex serve` 可直接运行；但 [Daemon 模式](#daemon-模式)与 `/upgrade` [自动升级](#自动升级)为 Linux 专属。离线环境请用 [手动安装 release 包](#release-资产) 或[从源码构建](../README.md#从源码构建)。
 
 ## Daemon 模式
 

--- a/install.ps1
+++ b/install.ps1
@@ -1,0 +1,151 @@
+<#
+.SYNOPSIS
+  Feidex one-line installer for Windows (PowerShell).
+
+.DESCRIPTION
+  Downloads the release binary for your architecture, verifies its SHA-256
+  against the release's sha256sums.txt, installs it to a bin directory, adds
+  that directory to your user PATH, and prints the next steps. No build
+  toolchain required.
+
+  One-liner:
+    irm https://raw.githubusercontent.com/yuhuan417/feidex/main/install.ps1 | iex
+
+  With options (download first, then run):
+    .\install.ps1 -Dev
+    .\install.ps1 -Version v0.222.0 -BinDir 'C:\tools\feidex'
+
+.PARAMETER Version  Install a specific version (default: latest release).
+.PARAMETER Dev      Install the latest dev build (dev-latest prerelease).
+.PARAMETER BinDir   Install directory (default: %LOCALAPPDATA%\Programs\feidex).
+.PARAMETER Repo     GitHub repo to install from (default: yuhuan417/feidex).
+.PARAMETER NoModifyPath  Do not add the bin dir to your user PATH.
+
+  Environment overrides: FEIDEX_VERSION, FEIDEX_REPO, FEIDEX_BIN_DIR
+#>
+[CmdletBinding()]
+param(
+  [string]$Version = $env:FEIDEX_VERSION,
+  [switch]$Dev,
+  [string]$BinDir = $env:FEIDEX_BIN_DIR,
+  [string]$Repo = $(if ($env:FEIDEX_REPO) { $env:FEIDEX_REPO } else { 'yuhuan417/feidex' }),
+  [switch]$NoModifyPath
+)
+
+$ErrorActionPreference = 'Stop'
+[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
+
+function Info($m) { Write-Host "==> $m" -ForegroundColor Cyan }
+function Ok($m)   { Write-Host "OK  $m" -ForegroundColor Green }
+function Warn($m) { Write-Warning $m }
+function Die($m)  { Write-Error $m; exit 1 }
+
+# ---- platform detection -------------------------------------------------------
+$archRaw = $env:PROCESSOR_ARCHITECTURE
+switch ($archRaw) {
+  'AMD64' { $goarch = 'amd64' }
+  'ARM64' { $goarch = 'arm64' }
+  'x86'   { Die 'unsupported architecture: x86 (need 64-bit Windows)' }
+  default { Die "unsupported architecture: $archRaw" }
+}
+$asset = "feidex-windows-$goarch.exe"
+
+# ---- resolve version ----------------------------------------------------------
+if ($Dev) {
+  $tag = 'dev-latest'
+} elseif ($Version) {
+  $tag = $Version
+} else {
+  Info "Resolving latest release of $Repo..."
+  try {
+    $rel = Invoke-RestMethod -Uri "https://api.github.com/repos/$Repo/releases/latest" `
+      -Headers @{ 'User-Agent' = 'feidex-install' }
+    $tag = $rel.tag_name
+  } catch {
+    Die "could not resolve latest release tag: $($_.Exception.Message)"
+  }
+  if (-not $tag) { Die 'could not resolve latest release tag' }
+}
+
+$base = "https://github.com/$Repo/releases/download/$tag"
+Info "Installing feidex $tag (windows/$goarch) - asset $asset"
+
+# ---- download + verify --------------------------------------------------------
+$tmp = Join-Path ([System.IO.Path]::GetTempPath()) ("feidex-install-" + [System.Guid]::NewGuid().ToString('N'))
+New-Item -ItemType Directory -Path $tmp -Force | Out-Null
+try {
+  $binTmp = Join-Path $tmp 'feidex.exe'
+  Info 'Downloading binary...'
+  try {
+    Invoke-WebRequest -Uri "$base/$asset" -OutFile $binTmp -UseBasicParsing
+  } catch {
+    Die "download failed: $base/$asset (does tag $tag exist?)"
+  }
+
+  Info 'Verifying SHA-256...'
+  $sumsPath = Join-Path $tmp 'sha256sums.txt'
+  $haveSums = $false
+  try {
+    Invoke-WebRequest -Uri "$base/sha256sums.txt" -OutFile $sumsPath -UseBasicParsing
+    $haveSums = $true
+  } catch {
+    Warn "sha256sums.txt not available for $tag; skipping verification"
+  }
+  # Verification failures below are intentionally fatal (not wrapped in catch).
+  if ($haveSums) {
+    $expected = $null
+    foreach ($line in Get-Content $sumsPath) {
+      $parts = $line -split '\s+', 2
+      if ($parts.Count -eq 2 -and ($parts[1] -replace '.*/', '') -eq $asset) {
+        $expected = $parts[0].ToLower(); break
+      }
+    }
+    if (-not $expected) { Die "no checksum entry for $asset in sha256sums.txt" }
+    $actual = (Get-FileHash -Algorithm SHA256 -Path $binTmp).Hash.ToLower()
+    if ($actual -ne $expected) {
+      Die "checksum mismatch for $asset`n  expected $expected`n  actual   $actual"
+    }
+    Ok 'checksum verified'
+  }
+
+  # ---- install ----------------------------------------------------------------
+  if (-not $BinDir) { $BinDir = Join-Path $env:LOCALAPPDATA 'Programs\feidex' }
+  New-Item -ItemType Directory -Path $BinDir -Force | Out-Null
+  $dest = Join-Path $BinDir 'feidex.exe'
+  Copy-Item -Path $binTmp -Destination $dest -Force
+  Ok "Installed to $dest"
+
+  try { & $dest version | Select-Object -First 1 | ForEach-Object { Ok $_ } } catch {}
+
+  # ---- PATH handling ----------------------------------------------------------
+  $userPath = [Environment]::GetEnvironmentVariable('Path', 'User')
+  $onPath = ($userPath -split ';') -contains $BinDir
+  if (-not $onPath) {
+    if (-not $NoModifyPath) {
+      $newPath = if ([string]::IsNullOrEmpty($userPath)) { $BinDir } else { "$userPath;$BinDir" }
+      [Environment]::SetEnvironmentVariable('Path', $newPath, 'User')
+      $env:Path = "$env:Path;$BinDir"
+      Ok "Added $BinDir to your user PATH (open a new terminal to pick it up)"
+    } else {
+      Warn "$BinDir is not on your PATH; add it manually."
+    }
+  }
+} finally {
+  Remove-Item -Recurse -Force $tmp -ErrorAction SilentlyContinue
+}
+
+Write-Host ""
+Write-Host "feidex $tag is installed." -ForegroundColor Green
+@"
+Next steps:
+  1. Bind a Feishu/Lark app and write config.toml:
+       feidex feishu setup                                  # 飞书（国内版）
+       feidex feishu bind --app ID:SECRET --domain lark     # Lark（国际版）
+  2. Start it:
+       feidex serve --config config.toml
+
+Note: the systemd daemon and /upgrade self-upgrade are Linux-only;
+on Windows run `feidex serve` directly (e.g. as a scheduled task or service).
+
+Docs: https://github.com/$Repo#readme
+"@ | Write-Host


### PR DESCRIPTION
## What

Feidex already compiles for Windows, but the release pipeline only built Linux/macOS, so there was nothing for a Windows installer to download. This adds the full Windows path:

- **CI**: a `Cross-build (Windows)` step (`GOOS=windows` amd64 + arm64) so Windows-only build breakage is caught on every PR.
- **Release** (dev + tagged jobs): build `feidex-windows-amd64.exe` / `feidex-windows-arm64.exe`, package them as `.zip`, add them to `sha256sums.txt`, and upload them.
- **install.ps1**: a PowerShell one-liner mirroring `install.sh`:
  ```powershell
  irm https://raw.githubusercontent.com/yuhuan417/feidex/main/install.ps1 | iex
  ```
  Arch detection, **mandatory SHA-256 verification** (download failure warns; mismatch / missing entry are fatal), install to `%LOCALAPPDATA%\Programs\feidex`, user-PATH update (`-NoModifyPath` to opt out), and `-Version` / `-Dev` / `-BinDir` / `-Repo` options + `FEIDEX_*` env overrides.
- **Docs**: README quick-start lists Windows (PowerShell) alongside Linux/macOS; `docs/operations.md` covers `install.ps1` options, the Windows assets, and the Linux-only daemon/upgrade caveat.

## Scope notes

- The systemd daemon and `/upgrade` self-upgrade stay **Linux-only**; on Windows users run `feidex serve` directly (e.g. as a scheduled task / service). `install.ps1` and the docs say so.
- CI does a Windows **cross-build** (compile check), not a full Windows test matrix — kept tight to avoid surfacing unrelated path-test failures; a windows-latest test job can be added later if desired.

## Testing

- `GOOS=windows GOARCH=amd64 go build ./...` and `arm64` both succeed locally (so the CI step and release builds will pass).
- `go.yml` change is build/package/checksum/upload additions only, mirroring the existing Linux/macOS targets.
- `install.ps1` reviewed for checksum fatality (a mismatch aborts rather than downgrading to a warning).

🤖 Generated with [Claude Code](https://claude.com/claude-code)