### PR TITLE
Add macOS daemon support via launchd

### DIFF
--- a/cmd/feidex/daemon.go
+++ b/cmd/feidex/daemon.go
@@ -251,8 +251,19 @@ func daemonLogs(args []string) int {
 		fmt.Fprintf(os.Stderr, "load config: %v\n", err)
 		return 1
 	}
-	unitName := daemon.NormalizeServiceName(cfg.Daemon.ServiceName) + ".service"
+	mgr, err := newDaemonManager(cfg.Daemon.ServiceName)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "daemon manager: %v\n", err)
+		return 1
+	}
 
+	// Platforms that log to a file (macOS launchd) are tailed directly;
+	// Linux logs live in systemd journald and are read with journalctl.
+	if logFile := mgr.LogFile(); logFile != "" {
+		return tailDaemonLogFile(logFile, *lines, *follow)
+	}
+
+	unitName := daemon.NormalizeServiceName(cfg.Daemon.ServiceName) + ".service"
 	if _, err := exec.LookPath("journalctl"); err != nil {
 		fmt.Fprintf(os.Stderr, "journalctl not found; daemon logs are managed by systemd journald on Linux\n")
 		fmt.Fprintf(os.Stderr, "You can view logs manually with: journalctl --user -u %s\n", unitName)
@@ -269,6 +280,31 @@ func daemonLogs(args []string) int {
 	cmd.Stderr = os.Stderr
 	if err := cmd.Run(); err != nil {
 		fmt.Fprintf(os.Stderr, "journalctl failed: %v\n", err)
+		return 1
+	}
+	return 0
+}
+
+func tailDaemonLogFile(path string, lines int, follow bool) int {
+	if _, err := os.Stat(path); err != nil {
+		if os.IsNotExist(err) {
+			fmt.Fprintf(os.Stderr, "log file not found yet: %s\n", path)
+			fmt.Fprintln(os.Stderr, "(it appears once the daemon has started and produced output)")
+			return 1
+		}
+		fmt.Fprintf(os.Stderr, "stat log file: %v\n", err)
+		return 1
+	}
+	tailArgs := []string{"-n", fmt.Sprintf("%d", lines)}
+	if follow {
+		tailArgs = append(tailArgs, "-f")
+	}
+	tailArgs = append(tailArgs, path)
+	cmd := exec.Command("tail", tailArgs...)
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	if err := cmd.Run(); err != nil {
+		fmt.Fprintf(os.Stderr, "tail failed: %v\n", err)
 		return 1
 	}
 	return 0

--- a/cmd/feidex/main_test.go
+++ b/cmd/feidex/main_test.go
@@ -43,6 +43,7 @@ type fakeManager struct {
 	restartErr error
 	removeErr  error
 	platform   string
+	logFile    string
 	installCfg daemon.Config
 	calls      []string
 }
@@ -83,6 +84,10 @@ func (f *fakeManager) Platform() string {
 		return f.platform
 	}
 	return "test"
+}
+
+func (f *fakeManager) LogFile() string {
+	return f.logFile
 }
 
 func withCapturedOutput(t *testing.T, fn func()) (stdout string, stderr string) {

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -48,7 +48,7 @@ irm https://raw.githubusercontent.com/yuhuan417/feidex/main/install.ps1 | iex
 
 ## Daemon 模式
 
-Feidex 支持 Linux 用户态 systemd daemon。
+Feidex 支持把自己作为后台守护进程常驻：Linux 用 systemd 用户服务，macOS 用 launchd 用户级 LaunchAgent。两者命令一致，平台差异由 `feidex daemon` 自动处理。
 
 命令：
 
@@ -73,16 +73,33 @@ feidex daemon uninstall
 - `start` / `stop` / `restart` / `status` / `uninstall`
   - 也默认读取当前目录的 `config.toml`，按其中的 `[daemon].service_name` 选择实例
 - `logs`
-  - 通过 `journalctl --user -u <service>.service` 查看当前 daemon 日志
+  - Linux：通过 `journalctl --user -u <service>.service` 查看
+  - macOS：tail launchd 写入的日志文件（见下文 macOS 小节）
   - `-n` 控制输出行数，`-f` 持续跟随
-  - 依赖 Linux/systemd journald
 - `upgrade-runner`
   - 内部升级 runner，不需要手动调用
+
+### Linux（systemd 用户服务）
+
+- unit 文件写在 `~/.config/systemd/user/<service>.service`
+- `install` 默认尝试为当前用户开启 linger（开机/登出后仍运行）；不想改这个设置用 `--disable-linger`
+- 日志由 journald 管理，`feidex daemon logs` 走 `journalctl`
+
+### macOS（launchd LaunchAgent）
+
+- plist 写在 `~/Library/LaunchAgents/<service>.plist`，通过 `launchctl bootstrap` / `bootout` / `kickstart` 管理
+- `RunAtLoad` + `KeepAlive`：登录后自动启动、崩溃自动拉起
+- 日志：launchd 把 stdout/stderr 写到 `~/Library/Logs/feidex/<service>.log`，`feidex daemon logs` 直接 tail 该文件
+- `enable-linger` 在 macOS 上是 no-op（LaunchAgent 登录即起）。**开机即起（免登录）需要 root 级 LaunchDaemon，当前不支持**
+- 若二进制是从浏览器下载被 Gatekeeper 隔离，先 `xattr -d com.apple.quarantine <binary>`（用 `install.sh` 经 curl 安装则无此问题）
+
+> macOS daemon 仅负责常驻；`/upgrade` 自升级仍为 Linux 专属（见[自动升级](#自动升级)），macOS 升级请用 [install.sh](#一键安装脚本) 重新安装。
 
 对应实现见：
 
 - [daemon.go](../cmd/feidex/daemon.go)
 - [manager.go](../internal/daemon/manager.go)
+- [systemd_linux.go](../internal/daemon/systemd_linux.go) / [launchd_darwin.go](../internal/daemon/launchd_darwin.go)
 
 ## 自动升级
 

--- a/internal/daemon/launchd_darwin.go
+++ b/internal/daemon/launchd_darwin.go
@@ -1,0 +1,216 @@
+//go:build darwin
+
+package daemon
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strconv"
+	"strings"
+)
+
+type launchdManager struct {
+	serviceName string
+}
+
+func newPlatformManager(serviceName string) (Manager, error) {
+	if os.Getuid() == 0 {
+		return nil, fmt.Errorf("launchd install supports per-user LaunchAgents only; run as the target user instead of root")
+	}
+	if _, err := exec.LookPath("launchctl"); err != nil {
+		return nil, fmt.Errorf("launchctl not found: launchd is required on macOS")
+	}
+	return &launchdManager{serviceName: normalizeServiceName(serviceName)}, nil
+}
+
+func (m *launchdManager) Platform() string {
+	return "launchd (macOS)"
+}
+
+// LogFile returns the file launchd writes the agent's stdout/stderr to.
+func (m *launchdManager) LogFile() string {
+	home, _ := os.UserHomeDir()
+	return filepath.Join(home, "Library", "Logs", "feidex", m.label()+".log")
+}
+
+func (m *launchdManager) Install(cfg Config) error {
+	plistPath := m.plistPath()
+	if err := os.MkdirAll(filepath.Dir(plistPath), 0o755); err != nil {
+		return fmt.Errorf("create LaunchAgents dir: %w", err)
+	}
+	if err := os.MkdirAll(filepath.Dir(m.LogFile()), 0o755); err != nil {
+		return fmt.Errorf("create log dir: %w", err)
+	}
+	if err := os.WriteFile(plistPath, []byte(m.buildPlist(cfg)), 0o644); err != nil {
+		return fmt.Errorf("write plist: %w", err)
+	}
+	// Clear any stale registration so bootstrap does not fail with
+	// "service already bootstrapped".
+	_, _ = runLaunchctl("bootout", m.serviceTarget())
+	if out, err := runLaunchctl("bootstrap", m.domainTarget(), plistPath); err != nil {
+		return fmt.Errorf("launchctl bootstrap: %s (%w)", out, err)
+	}
+	if out, err := runLaunchctl("kickstart", "-k", m.serviceTarget()); err != nil {
+		return fmt.Errorf("launchctl kickstart: %s (%w)", out, err)
+	}
+	return nil
+}
+
+func (m *launchdManager) Uninstall() error {
+	_, _ = runLaunchctl("bootout", m.serviceTarget()) // best-effort unload
+	if err := os.Remove(m.plistPath()); err != nil && !os.IsNotExist(err) {
+		return fmt.Errorf("remove plist: %w", err)
+	}
+	return nil
+}
+
+func (m *launchdManager) Start() error {
+	// bootstrap loads the agent (RunAtLoad starts it); tolerate "already
+	// bootstrapped" and let kickstart guarantee it is running.
+	_, _ = runLaunchctl("bootstrap", m.domainTarget(), m.plistPath())
+	if out, err := runLaunchctl("kickstart", m.serviceTarget()); err != nil {
+		return fmt.Errorf("start: %s (%w)", out, err)
+	}
+	return nil
+}
+
+func (m *launchdManager) Stop() error {
+	// launchd has no "stop but keep loaded" for a KeepAlive agent; bootout
+	// unloads it, which is the durable way to stop.
+	if out, err := runLaunchctl("bootout", m.serviceTarget()); err != nil {
+		return fmt.Errorf("stop: %s (%w)", out, err)
+	}
+	return nil
+}
+
+func (m *launchdManager) Restart() error {
+	_, _ = runLaunchctl("bootstrap", m.domainTarget(), m.plistPath()) // ensure loaded
+	if out, err := runLaunchctl("kickstart", "-k", m.serviceTarget()); err != nil {
+		return fmt.Errorf("restart: %s (%w)", out, err)
+	}
+	return nil
+}
+
+func (m *launchdManager) Status() (*Status, error) {
+	st := &Status{
+		Platform: m.Platform(),
+		UnitPath: m.plistPath(),
+	}
+	if _, err := os.Stat(st.UnitPath); err != nil {
+		if os.IsNotExist(err) {
+			return st, nil
+		}
+		return nil, err
+	}
+	st.Installed = true
+	out, err := runLaunchctl("print", m.serviceTarget())
+	if err != nil {
+		// Plist present but not loaded: installed, not running.
+		return st, nil
+	}
+	running, pid := parseLaunchctlPrint(out)
+	st.Running = running
+	st.PID = pid
+	return st, nil
+}
+
+func (m *launchdManager) label() string {
+	return normalizeServiceName(m.serviceName)
+}
+
+func (m *launchdManager) plistPath() string {
+	home, _ := os.UserHomeDir()
+	return filepath.Join(home, "Library", "LaunchAgents", m.label()+".plist")
+}
+
+func (m *launchdManager) domainTarget() string {
+	return fmt.Sprintf("gui/%d", os.Getuid())
+}
+
+func (m *launchdManager) serviceTarget() string {
+	return fmt.Sprintf("gui/%d/%s", os.Getuid(), m.label())
+}
+
+func (m *launchdManager) buildPlist(cfg Config) string {
+	logPath := m.LogFile()
+	var sb strings.Builder
+	sb.WriteString(`<?xml version="1.0" encoding="UTF-8"?>` + "\n")
+	sb.WriteString(`<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">` + "\n")
+	sb.WriteString(`<plist version="1.0">` + "\n")
+	sb.WriteString("<dict>\n")
+	plistKeyString(&sb, "Label", m.label())
+	sb.WriteString("\t<key>ProgramArguments</key>\n\t<array>\n")
+	for _, arg := range []string{cfg.BinaryPath, "serve", "--config", cfg.ConfigPath} {
+		fmt.Fprintf(&sb, "\t\t<string>%s</string>\n", xmlEscape(arg))
+	}
+	sb.WriteString("\t</array>\n")
+	plistKeyString(&sb, "WorkingDirectory", cfg.WorkDir)
+	sb.WriteString("\t<key>EnvironmentVariables</key>\n\t<dict>\n")
+	if strings.TrimSpace(cfg.EnvPATH) != "" {
+		plistKeyStringIndent(&sb, "PATH", cfg.EnvPATH, "\t\t")
+	}
+	if strings.TrimSpace(cfg.HomeDir) != "" {
+		plistKeyStringIndent(&sb, "HOME", cfg.HomeDir, "\t\t")
+	}
+	sb.WriteString("\t</dict>\n")
+	plistKeyBool(&sb, "RunAtLoad", true)
+	plistKeyBool(&sb, "KeepAlive", true)
+	plistKeyString(&sb, "StandardOutPath", logPath)
+	plistKeyString(&sb, "StandardErrorPath", logPath)
+	plistKeyString(&sb, "ProcessType", "Background")
+	sb.WriteString("</dict>\n</plist>\n")
+	return sb.String()
+}
+
+func plistKeyString(sb *strings.Builder, key, value string) {
+	plistKeyStringIndent(sb, key, value, "\t")
+}
+
+func plistKeyStringIndent(sb *strings.Builder, key, value, indent string) {
+	fmt.Fprintf(sb, "%s<key>%s</key>\n%s<string>%s</string>\n", indent, xmlEscape(key), indent, xmlEscape(value))
+}
+
+func plistKeyBool(sb *strings.Builder, key string, value bool) {
+	tag := "<false/>"
+	if value {
+		tag = "<true/>"
+	}
+	fmt.Fprintf(sb, "\t<key>%s</key>\n\t%s\n", xmlEscape(key), tag)
+}
+
+func xmlEscape(s string) string {
+	r := strings.NewReplacer("&", "&amp;", "<", "&lt;", ">", "&gt;", `"`, "&quot;", "'", "&apos;")
+	return r.Replace(s)
+}
+
+// parseLaunchctlPrint extracts running state and PID from `launchctl print`
+// output, whose body contains lines like "state = running" and "pid = 1234".
+func parseLaunchctlPrint(out string) (running bool, pid int) {
+	for _, line := range strings.Split(out, "\n") {
+		line = strings.TrimSpace(line)
+		if v, ok := strings.CutPrefix(line, "state = "); ok {
+			running = strings.EqualFold(strings.TrimSpace(v), "running")
+		}
+		if v, ok := strings.CutPrefix(line, "pid = "); ok {
+			if n, err := strconv.Atoi(strings.TrimSpace(v)); err == nil {
+				pid = n
+			}
+		}
+	}
+	return running, pid
+}
+
+func runLaunchctl(args ...string) (string, error) {
+	cmd := exec.Command("launchctl", args...)
+	out, err := cmd.CombinedOutput()
+	return strings.TrimSpace(string(out)), err
+}
+
+// EnableLingerCurrentUser is a no-op on macOS: a LaunchAgent starts at user
+// login and is kept alive by launchd. There is no systemd-style "linger"; to
+// run before login you would need a root LaunchDaemon, which is out of scope.
+func EnableLingerCurrentUser() error {
+	return nil
+}

--- a/internal/daemon/launchd_darwin_test.go
+++ b/internal/daemon/launchd_darwin_test.go
@@ -1,0 +1,160 @@
+//go:build darwin
+
+package daemon
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func writeExecutable(t *testing.T, dir, name, body string) string {
+	t.Helper()
+	path := filepath.Join(dir, name)
+	script := "#!/bin/sh\nset -eu\n" + body + "\n"
+	if err := os.WriteFile(path, []byte(script), 0o755); err != nil {
+		t.Fatalf("WriteFile(%s) error = %v", name, err)
+	}
+	return path
+}
+
+func TestBuildPlistContent(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	mgr := &launchdManager{serviceName: DefaultServiceName}
+	plist := mgr.buildPlist(Config{
+		BinaryPath: "/opt/feidex/bin/feidex",
+		ConfigPath: "/Users/tester/config.toml",
+		WorkDir:    "/Users/tester",
+		EnvPATH:    "/usr/local/bin:/usr/bin",
+		HomeDir:    "/Users/tester",
+	})
+	for _, want := range []string{
+		"<key>Label</key>\n\t<string>feidex</string>",
+		"<key>ProgramArguments</key>",
+		"<string>/opt/feidex/bin/feidex</string>",
+		"<string>serve</string>",
+		"<string>--config</string>",
+		"<string>/Users/tester/config.toml</string>",
+		"<key>WorkingDirectory</key>\n\t<string>/Users/tester</string>",
+		"<key>PATH</key>\n\t\t<string>/usr/local/bin:/usr/bin</string>",
+		"<key>HOME</key>\n\t\t<string>/Users/tester</string>",
+		"<key>RunAtLoad</key>\n\t<true/>",
+		"<key>KeepAlive</key>\n\t<true/>",
+		"<key>ProcessType</key>\n\t<string>Background</string>",
+		"Library/Logs/feidex/feidex.log",
+	} {
+		if !strings.Contains(plist, want) {
+			t.Fatalf("plist missing %q:\n%s", want, plist)
+		}
+	}
+}
+
+func TestBuildPlistEscapesXML(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	mgr := &launchdManager{serviceName: DefaultServiceName}
+	plist := mgr.buildPlist(Config{
+		BinaryPath: "/opt/a&b/feidex",
+		ConfigPath: "/Users/x <y>/config.toml",
+		WorkDir:    "/Users/x <y>",
+	})
+	for _, want := range []string{
+		"<string>/opt/a&amp;b/feidex</string>",
+		"<string>/Users/x &lt;y&gt;/config.toml</string>",
+	} {
+		if !strings.Contains(plist, want) {
+			t.Fatalf("plist missing escaped value %q:\n%s", want, plist)
+		}
+	}
+}
+
+func TestParseLaunchctlPrint(t *testing.T) {
+	out := "gui/501/feidex = {\n\tstate = running\n\tpid = 456\n}\n"
+	running, pid := parseLaunchctlPrint(out)
+	if !running || pid != 456 {
+		t.Fatalf("parseLaunchctlPrint() = running=%v pid=%d, want true/456", running, pid)
+	}
+	running, pid = parseLaunchctlPrint("gui/501/feidex = {\n\tstate = not running\n}\n")
+	if running || pid != 0 {
+		t.Fatalf("parseLaunchctlPrint(stopped) = running=%v pid=%d, want false/0", running, pid)
+	}
+}
+
+func TestLaunchdLifecycleWithFakeLaunchctl(t *testing.T) {
+	home := t.TempDir()
+	binDir := t.TempDir()
+	logPath := filepath.Join(t.TempDir(), "launchctl.log")
+	writeExecutable(t, binDir, "launchctl", `
+printf '%s\n' "$*" >> "$LAUNCHCTL_LOG"
+case " $* " in
+  *" print "*)
+  printf 'gui/0/feidex = {\n\tstate = running\n\tpid = 456\n}\n'
+  ;;
+esac
+`)
+	t.Setenv("HOME", home)
+	t.Setenv("PATH", binDir)
+	t.Setenv("LAUNCHCTL_LOG", logPath)
+
+	manager, err := newPlatformManager(DefaultServiceName)
+	if err != nil {
+		t.Fatalf("newPlatformManager() error = %v", err)
+	}
+
+	cfg := Config{BinaryPath: "/opt/feidex/bin/feidex", ConfigPath: "/tmp/config.toml", WorkDir: "/tmp"}
+	if err := manager.Install(cfg); err != nil {
+		t.Fatalf("Install() error = %v", err)
+	}
+	// plist file written under fake HOME
+	plistPath := filepath.Join(home, "Library", "LaunchAgents", "feidex.plist")
+	if _, err := os.Stat(plistPath); err != nil {
+		t.Fatalf("plist not written: %v", err)
+	}
+
+	status, err := manager.Status()
+	if err != nil {
+		t.Fatalf("Status() error = %v", err)
+	}
+	if status == nil || !status.Installed || !status.Running || status.PID != 456 {
+		t.Fatalf("Status() = %+v, want installed running pid=456", status)
+	}
+	if manager.LogFile() == "" {
+		t.Fatal("LogFile() should be non-empty on macOS")
+	}
+	for _, step := range []func() error{manager.Start, manager.Stop, manager.Restart} {
+		if err := step(); err != nil {
+			t.Fatalf("lifecycle step error = %v", err)
+		}
+	}
+	if err := manager.Uninstall(); err != nil {
+		t.Fatalf("Uninstall() error = %v", err)
+	}
+	if st, err := manager.Status(); err != nil || st == nil || st.Installed {
+		t.Fatalf("Status(after uninstall) = %+v, %v, want not installed", st, err)
+	}
+
+	logContent, err := os.ReadFile(logPath)
+	if err != nil {
+		t.Fatalf("ReadFile(log) error = %v", err)
+	}
+	text := string(logContent)
+	uid := os.Getuid()
+	for _, want := range []string{
+		fmt.Sprintf("bootstrap gui/%d", uid),
+		fmt.Sprintf("kickstart -k gui/%d/feidex", uid),
+		fmt.Sprintf("kickstart gui/%d/feidex", uid),
+		fmt.Sprintf("bootout gui/%d/feidex", uid),
+		fmt.Sprintf("print gui/%d/feidex", uid),
+	} {
+		if !strings.Contains(text, want) {
+			t.Fatalf("launchctl log missing %q:\n%s", want, text)
+		}
+	}
+}
+
+func TestEnableLingerNoopOnDarwin(t *testing.T) {
+	if err := EnableLingerCurrentUser(); err != nil {
+		t.Fatalf("EnableLingerCurrentUser() on darwin = %v, want nil", err)
+	}
+}

--- a/internal/daemon/manager.go
+++ b/internal/daemon/manager.go
@@ -33,6 +33,10 @@ type Manager interface {
 	Restart() error
 	Status() (*Status, error)
 	Platform() string
+	// LogFile returns the path the daemon's stdout/stderr is written to, or
+	// "" when logs are managed by the platform log system (e.g. systemd
+	// journald on Linux). The CLI tails this file when it is non-empty.
+	LogFile() string
 }
 
 func NewManager(serviceName string) (Manager, error) {

--- a/internal/daemon/systemd_linux.go
+++ b/internal/daemon/systemd_linux.go
@@ -30,6 +30,12 @@ func (m *systemdManager) Platform() string {
 	return "systemd (user)"
 }
 
+// LogFile returns "" because logs are captured by systemd journald; the CLI
+// reads them with journalctl rather than tailing a file.
+func (m *systemdManager) LogFile() string {
+	return ""
+}
+
 func (m *systemdManager) Install(cfg Config) error {
 	unitPath := m.unitPath()
 	if err := os.MkdirAll(filepath.Dir(unitPath), 0o755); err != nil {

--- a/internal/daemon/unsupported.go
+++ b/internal/daemon/unsupported.go
@@ -1,4 +1,4 @@
-//go:build !linux
+//go:build !linux && !darwin
 
 package daemon
 

--- a/internal/daemon/upgrade_linux_test.go
+++ b/internal/daemon/upgrade_linux_test.go
@@ -28,6 +28,7 @@ type fakeUpgradeManager struct {
 func (m *fakeUpgradeManager) Install(Config) error { return nil }
 func (m *fakeUpgradeManager) Uninstall() error     { return nil }
 func (m *fakeUpgradeManager) Platform() string     { return "test" }
+func (m *fakeUpgradeManager) LogFile() string      { return "" }
 func (m *fakeUpgradeManager) Restart() error       { return nil }
 func (m *fakeUpgradeManager) Start() error {
 	m.mu.Lock()


### PR DESCRIPTION
## What

`feidex daemon` previously only supported Linux/systemd — on macOS it errored with "not supported". This adds a **launchd LaunchAgent** backend so the same `feidex daemon …` commands work on macOS.

## Change

- **`internal/daemon/launchd_darwin.go`** (`//go:build darwin`) — `launchdManager` implementing the existing `Manager` interface:
  - **Install**: writes a LaunchAgent plist to `~/Library/LaunchAgents/<service>.plist` (`ProgramArguments` = `serve --config <path>`, `WorkingDirectory`, `PATH`/`HOME` env, `RunAtLoad`, `KeepAlive`, `ProcessType=Background`, stdout/stderr → `~/Library/Logs/feidex/<service>.log`), then `launchctl bootstrap` + `kickstart`.
  - **Uninstall / Start / Stop / Restart** → `bootout` / `bootstrap` / `kickstart`.
  - **Status** parses `launchctl print` for running state + PID.
- **`Manager.LogFile()`** added: `""` on Linux (journald), the log-file path on macOS. `feidex daemon logs` tails the file when non-empty, otherwise uses `journalctl`. `unsupported.go` retightened to `!linux && !darwin`.
- **`EnableLingerCurrentUser`** is a no-op on macOS (LaunchAgents start at login); `enable-linger` remains a systemd concept.
- **Docs**: `docs/operations.md` documents the macOS (launchd) path next to Linux, including the log location and the Gatekeeper-quarantine note.

## Scope

- macOS daemon **lifecycle + logs only**. `/upgrade` self-upgrade stays **Linux-only** (on macOS re-run `install.sh` to upgrade). Boot-time start (root `LaunchDaemon`) is out of scope.

## Testing

- `launchd_darwin_test.go` fakes `launchctl` on `PATH` and asserts the bootstrap/kickstart/bootout/print call sequence + generated plist content (mirrors the existing systemd tests). Also unit-tests the plist builder (incl. XML escaping) and `launchctl print` parsing.
- Builds and vets clean on **darwin / linux / windows**; `go test -race ./internal/daemon ./cmd/feidex` passes.
- Real read-only check on macOS: `feidex daemon status` reports `Platform: launchd (macOS)` with the correct plist path; `feidex daemon logs` gives a friendly "not started yet" hint.

🤖 Generated with [Claude Code](https://claude.com/claude-code)