### PR TITLE
Add Windows daemon support via Task Scheduler (no admin)

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ curl -fsSL https://raw.githubusercontent.com/yuhuan417/feidex/main/install.sh | 
 irm https://raw.githubusercontent.com/yuhuan417/feidex/main/install.ps1 | iex
 ```
 
-> Windows 上 `feidex serve` 可直接运行；systemd daemon 与 `/upgrade` 自升级为 Linux 专属。
+> Windows 上 `feidex serve` 可直接运行，[daemon 模式](docs/operations.md#daemon-模式)也已支持（计划任务，免管理员）；仅 `/upgrade` 自升级为 Linux 专属。
 
 安装选项见 [安装脚本](docs/operations.md#一键安装脚本)。
 

--- a/cmd/feidex/daemon.go
+++ b/cmd/feidex/daemon.go
@@ -4,8 +4,12 @@ import (
 	"context"
 	"flag"
 	"fmt"
+	"io"
 	"os"
 	"os/exec"
+	"runtime"
+	"strings"
+	"time"
 
 	"feidex/internal/buildinfo"
 	"feidex/internal/config"
@@ -295,6 +299,15 @@ func tailDaemonLogFile(path string, lines int, follow bool) int {
 		fmt.Fprintf(os.Stderr, "stat log file: %v\n", err)
 		return 1
 	}
+	// Windows has no `tail` binary; use a built-in tail there. On Unix the
+	// system `tail` stays the default so behavior is unchanged.
+	if runtime.GOOS == "windows" {
+		if err := goTailFile(path, lines, follow, os.Stdout); err != nil {
+			fmt.Fprintf(os.Stderr, "tail failed: %v\n", err)
+			return 1
+		}
+		return 0
+	}
 	tailArgs := []string{"-n", fmt.Sprintf("%d", lines)}
 	if follow {
 		tailArgs = append(tailArgs, "-f")
@@ -308,6 +321,54 @@ func tailDaemonLogFile(path string, lines int, follow bool) int {
 		return 1
 	}
 	return 0
+}
+
+// goTailFile prints the last n lines of a file and, when follow is set, keeps
+// printing appended content until interrupted. It is a minimal cross-platform
+// stand-in for `tail -n N [-f]`, used on Windows where `tail` is absent.
+func goTailFile(path string, n int, follow bool, out io.Writer) error {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return err
+	}
+	lines := strings.Split(string(data), "\n")
+	// A trailing newline yields a final empty element; drop it so counts match.
+	if len(lines) > 0 && lines[len(lines)-1] == "" {
+		lines = lines[:len(lines)-1]
+	}
+	start := 0
+	if n >= 0 && len(lines) > n {
+		start = len(lines) - n
+	}
+	for _, line := range lines[start:] {
+		fmt.Fprintln(out, line)
+	}
+	if !follow {
+		return nil
+	}
+	offset := int64(len(data))
+	for {
+		time.Sleep(time.Second)
+		f, err := os.Open(path)
+		if err != nil {
+			return err
+		}
+		if _, err := f.Seek(offset, io.SeekStart); err != nil {
+			f.Close()
+			return err
+		}
+		buf, err := io.ReadAll(f)
+		f.Close()
+		if err != nil {
+			return err
+		}
+		if len(buf) > 0 {
+			if _, err := out.Write(buf); err != nil {
+				return err
+			}
+			offset += int64(len(buf))
+		}
+	}
 }
 
 func daemonUpgradeRunner(args []string) int {

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -44,11 +44,11 @@ irm https://raw.githubusercontent.com/yuhuan417/feidex/main/install.ps1 | iex
 - 原子替换（可重复执行以升级；二进制正被占用时也安全）
 - 安装目录不在 PATH 时，提示或写入 PATH（`--no-modify-path` / `-NoModifyPath` 可关闭）
 
-> Windows 上 `feidex serve` 可直接运行；但 [Daemon 模式](#daemon-模式)与 `/upgrade` [自动升级](#自动升级)为 Linux 专属。离线环境请用 [手动安装 release 包](#release-资产) 或[从源码构建](../README.md#从源码构建)。
+> Windows 上 `feidex serve` 可直接运行，[Daemon 模式](#daemon-模式)也已支持（计划任务，免管理员）；但 `/upgrade` [自动升级](#自动升级)仍为 Linux 专属。离线环境请用 [手动安装 release 包](#release-资产) 或[从源码构建](../README.md#从源码构建)。
 
 ## Daemon 模式
 
-Feidex 支持把自己作为后台守护进程常驻：Linux 用 systemd 用户服务，macOS 用 launchd 用户级 LaunchAgent。两者命令一致，平台差异由 `feidex daemon` 自动处理。
+Feidex 支持把自己作为后台守护进程常驻：Linux 用 systemd 用户服务，macOS 用 launchd 用户级 LaunchAgent，Windows 用计划任务（Task Scheduler，免管理员）。三者命令一致，平台差异由 `feidex daemon` 自动处理。
 
 命令：
 
@@ -74,7 +74,7 @@ feidex daemon uninstall
   - 也默认读取当前目录的 `config.toml`，按其中的 `[daemon].service_name` 选择实例
 - `logs`
   - Linux：通过 `journalctl --user -u <service>.service` 查看
-  - macOS：tail launchd 写入的日志文件（见下文 macOS 小节）
+  - macOS / Windows：tail 守护进程写入的日志文件（见下文对应小节）
   - `-n` 控制输出行数，`-f` 持续跟随
 - `upgrade-runner`
   - 内部升级 runner，不需要手动调用
@@ -95,11 +95,23 @@ feidex daemon uninstall
 
 > macOS daemon 仅负责常驻；`/upgrade` 自升级仍为 Linux 专属（见[自动升级](#自动升级)），macOS 升级请用 [install.sh](#一键安装脚本) 重新安装。
 
+### Windows（Task Scheduler 计划任务）
+
+- **全程免管理员**：创建的是当前用户的计划任务，不需要 UAC 提权，也不需要保存密码
+- 任务名即 `<service>`（默认 `feidex`），用 `schtasks` 创建/删除/启停；安装时写一份任务 XML（`%LOCALAPPDATA%\feidex\<service>-task.xml`）
+- 触发器为「登录时」（at-logon），主体为 `InteractiveToken` + `LeastPrivilege`：登录即起、崩溃自动重启（任务设置 `RestartOnFailure`）
+- 任务动作通过 `wscript.exe` 拉起一个无窗口启动器（`%LOCALAPPDATA%\feidex\<service>-launch.vbs`），所以**不会弹出黑色命令行窗口**；启动器把 `feidex serve` 的 stdout/stderr 追加写到 `%LOCALAPPDATA%\feidex\<service>.log`
+- 日志：`feidex daemon logs` 直接 tail 上面那个日志文件（Windows 无 `tail`，由内置实现）
+- `enable-linger` 在 Windows 上是 no-op。**与 macOS LaunchAgent 一致，daemon 仅在该用户登录会话内运行；注销即停止**。注销后仍运行需要 Windows 服务或保存账户凭据，会引入提权/密码成本，当前刻意不做
+- 运行状态用 PowerShell `Get-ScheduledTask` 的 `State` 判定（语言无关，避免 `schtasks` 本地化文案）
+
+> Windows daemon 同样仅负责常驻；`/upgrade` 自升级仍为 Linux 专属（见[自动升级](#自动升级)），Windows 升级请用 [install.ps1](#一键安装脚本) 重新安装。
+
 对应实现见：
 
 - [daemon.go](../cmd/feidex/daemon.go)
 - [manager.go](../internal/daemon/manager.go)
-- [systemd_linux.go](../internal/daemon/systemd_linux.go) / [launchd_darwin.go](../internal/daemon/launchd_darwin.go)
+- [systemd_linux.go](../internal/daemon/systemd_linux.go) / [launchd_darwin.go](../internal/daemon/launchd_darwin.go) / [schtasks_windows.go](../internal/daemon/schtasks_windows.go)
 
 ## 自动升级
 

--- a/install.ps1
+++ b/install.ps1
@@ -144,8 +144,12 @@ Next steps:
   2. Start it:
        feidex serve --config config.toml
 
-Note: the systemd daemon and /upgrade self-upgrade are Linux-only;
-on Windows run `feidex serve` directly (e.g. as a scheduled task or service).
+  3. Or run it in the background as a daemon (Task Scheduler, no admin needed):
+       feidex daemon install --config config.toml
+       feidex daemon status
+
+Note: /upgrade self-upgrade is Linux-only; to update on Windows, re-run this
+installer. The daemon runs within your login session (stops at sign-out).
 
 Docs: https://github.com/$Repo#readme
 "@ | Write-Host

--- a/internal/app/app_more_test.go
+++ b/internal/app/app_more_test.go
@@ -167,6 +167,7 @@ func (f *fakeDaemonManagerForApp) Status() (*daemon.Status, error) {
 	return f.status, f.err
 }
 func (f *fakeDaemonManagerForApp) Platform() string { return "test" }
+func (f *fakeDaemonManagerForApp) LogFile() string  { return "" }
 
 func (f *fakeCodexClient) SetHandlers(onNotification func(string, json.RawMessage), onRequest func(codexrpc.RequestEnvelope)) {
 	f.mu.Lock()

--- a/internal/daemon/schtasks_windows.go
+++ b/internal/daemon/schtasks_windows.go
@@ -1,0 +1,286 @@
+//go:build windows
+
+package daemon
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"os/user"
+	"path/filepath"
+	"strings"
+	"unicode/utf16"
+)
+
+// schtasksManager runs Feidex as a per-user Windows Scheduled Task.
+//
+// This is the no-admin equivalent of the Linux user systemd unit and the macOS
+// per-user LaunchAgent: a task scoped to the current user needs no elevation, an
+// at-logon trigger starts it automatically, and Task Scheduler restarts it on
+// failure. Like the macOS LaunchAgent, it runs only while the user is logged on;
+// surviving logout would require stored credentials or a Windows service, both of
+// which pull in privileges or a password we deliberately avoid.
+//
+// The task action launches a generated VBScript through wscript.exe. wscript is a
+// windowless (GUI-subsystem) host, so the daemon starts with no flashing console
+// window; the script runs `feidex serve` via cmd with stdout/stderr redirected to
+// a log file and waits on it, so the task stays in the Running state for as long
+// as the daemon lives and propagates its exit code for restart-on-failure.
+type schtasksManager struct {
+	serviceName string
+}
+
+func newPlatformManager(serviceName string) (Manager, error) {
+	if _, err := exec.LookPath("schtasks"); err != nil {
+		return nil, fmt.Errorf("schtasks.exe not found: Windows Task Scheduler is required")
+	}
+	return &schtasksManager{serviceName: normalizeServiceName(serviceName)}, nil
+}
+
+func (m *schtasksManager) Platform() string {
+	return "Task Scheduler (Windows)"
+}
+
+func (m *schtasksManager) taskName() string {
+	return normalizeServiceName(m.serviceName)
+}
+
+// stateDir holds the generated launcher script, task XML, and log file. It mirrors
+// where macOS keeps its LaunchAgent log: a per-user, non-roaming location.
+func (m *schtasksManager) stateDir() string {
+	base := strings.TrimSpace(os.Getenv("LOCALAPPDATA"))
+	if base == "" {
+		if home, err := os.UserHomeDir(); err == nil {
+			base = filepath.Join(home, "AppData", "Local")
+		}
+	}
+	return filepath.Join(base, "feidex")
+}
+
+// LogFile returns the file the daemon's stdout/stderr is redirected to. The CLI
+// tails this file, the same way it does for the macOS LaunchAgent log.
+func (m *schtasksManager) LogFile() string {
+	return filepath.Join(m.stateDir(), m.taskName()+".log")
+}
+
+func (m *schtasksManager) launcherPath() string {
+	return filepath.Join(m.stateDir(), m.taskName()+"-launch.vbs")
+}
+
+func (m *schtasksManager) taskXMLPath() string {
+	return filepath.Join(m.stateDir(), m.taskName()+"-task.xml")
+}
+
+func (m *schtasksManager) Install(cfg Config) error {
+	if err := os.MkdirAll(m.stateDir(), 0o755); err != nil {
+		return fmt.Errorf("create state dir: %w", err)
+	}
+	if err := os.WriteFile(m.launcherPath(), []byte(m.buildLauncherVBS(cfg)), 0o644); err != nil {
+		return fmt.Errorf("write launcher: %w", err)
+	}
+	xml, err := m.buildTaskXML()
+	if err != nil {
+		return fmt.Errorf("build task xml: %w", err)
+	}
+	// schtasks /Create /XML requires a UTF-16 (LE, BOM) document.
+	if err := os.WriteFile(m.taskXMLPath(), encodeUTF16LE(xml), 0o644); err != nil {
+		return fmt.Errorf("write task xml: %w", err)
+	}
+	// /F replaces any existing task so reinstall is idempotent.
+	if out, err := runSchtasks("/Create", "/TN", m.taskName(), "/XML", m.taskXMLPath(), "/F"); err != nil {
+		return fmt.Errorf("schtasks create: %s (%w)", out, err)
+	}
+	if out, err := runSchtasks("/Run", "/TN", m.taskName()); err != nil {
+		return fmt.Errorf("schtasks run: %s (%w)", out, err)
+	}
+	return nil
+}
+
+func (m *schtasksManager) Uninstall() error {
+	_, _ = runSchtasks("/End", "/TN", m.taskName())          // best-effort stop
+	_, _ = runSchtasks("/Delete", "/TN", m.taskName(), "/F") // best-effort delete
+	if err := os.Remove(m.launcherPath()); err != nil && !os.IsNotExist(err) {
+		return fmt.Errorf("remove launcher: %w", err)
+	}
+	if err := os.Remove(m.taskXMLPath()); err != nil && !os.IsNotExist(err) {
+		return fmt.Errorf("remove task xml: %w", err)
+	}
+	return nil
+}
+
+func (m *schtasksManager) Start() error {
+	if out, err := runSchtasks("/Run", "/TN", m.taskName()); err != nil {
+		return fmt.Errorf("start: %s (%w)", out, err)
+	}
+	return nil
+}
+
+func (m *schtasksManager) Stop() error {
+	if out, err := runSchtasks("/End", "/TN", m.taskName()); err != nil {
+		return fmt.Errorf("stop: %s (%w)", out, err)
+	}
+	return nil
+}
+
+func (m *schtasksManager) Restart() error {
+	_, _ = runSchtasks("/End", "/TN", m.taskName())
+	if out, err := runSchtasks("/Run", "/TN", m.taskName()); err != nil {
+		return fmt.Errorf("restart: %s (%w)", out, err)
+	}
+	return nil
+}
+
+func (m *schtasksManager) Status() (*Status, error) {
+	st := &Status{
+		Platform: m.Platform(),
+		UnitPath: `Task Scheduler\` + m.taskName(),
+	}
+	// The scheduled task is the source of truth for "installed"; a zero exit
+	// from /Query means the task exists.
+	if _, err := runSchtasks("/Query", "/TN", m.taskName()); err != nil {
+		return st, nil
+	}
+	st.Installed = true
+	st.Running = m.taskRunning()
+	return st, nil
+}
+
+// taskRunning reports whether the scheduled task is currently executing. It reads
+// the task State via PowerShell's ScheduledTasks module because that value is a
+// culture-invariant enum ("Running"/"Ready"/"Disabled"), unlike the localized
+// text schtasks /Query prints. If PowerShell is unavailable it conservatively
+// reports false.
+func (m *schtasksManager) taskRunning() bool {
+	script := fmt.Sprintf(
+		"$ErrorActionPreference='SilentlyContinue';(Get-ScheduledTask -TaskName %s -TaskPath '\\').State",
+		powershellSingleQuote(m.taskName()),
+	)
+	out, err := runPowerShell(script)
+	if err != nil {
+		return false
+	}
+	return strings.EqualFold(strings.TrimSpace(out), "Running")
+}
+
+// buildLauncherVBS writes a tiny windowless launcher. wscript runs it with no
+// console; it starts `feidex serve` (output appended to the log file) hidden and
+// waits, exiting with the daemon's exit code so Task Scheduler can restart it on
+// failure.
+func (m *schtasksManager) buildLauncherVBS(cfg Config) string {
+	inner := fmt.Sprintf(`"%s" serve --config "%s" >> "%s" 2>&1`, cfg.BinaryPath, cfg.ConfigPath, m.LogFile())
+	cmdline := `cmd /c "` + inner + `"`
+	var sb strings.Builder
+	sb.WriteString("' Auto-generated by `feidex daemon install`. Do not edit.\r\n")
+	sb.WriteString("Set sh = CreateObject(\"WScript.Shell\")\r\n")
+	sb.WriteString("WScript.Quit sh.Run(" + vbsString(cmdline) + ", 0, True)\r\n")
+	return sb.String()
+}
+
+// buildTaskXML renders a Task Scheduler 1.2 document for a per-user, at-logon
+// task with restart-on-failure and no execution time limit.
+func (m *schtasksManager) buildTaskXML() (string, error) {
+	u, err := user.Current()
+	if err != nil {
+		return "", fmt.Errorf("current user: %w", err)
+	}
+	userID := u.Username
+	var sb strings.Builder
+	sb.WriteString(`<?xml version="1.0" encoding="UTF-16"?>` + "\r\n")
+	sb.WriteString(`<Task version="1.2" xmlns="http://schemas.microsoft.com/windows/2004/02/mit/task">` + "\r\n")
+	sb.WriteString("  <RegistrationInfo>\r\n")
+	fmt.Fprintf(&sb, "    <Description>%s - Feishu Codex Bridge</Description>\r\n", xmlEscape(m.taskName()))
+	sb.WriteString("  </RegistrationInfo>\r\n")
+	sb.WriteString("  <Triggers>\r\n")
+	sb.WriteString("    <LogonTrigger>\r\n")
+	sb.WriteString("      <Enabled>true</Enabled>\r\n")
+	fmt.Fprintf(&sb, "      <UserId>%s</UserId>\r\n", xmlEscape(userID))
+	sb.WriteString("    </LogonTrigger>\r\n")
+	sb.WriteString("  </Triggers>\r\n")
+	sb.WriteString("  <Principals>\r\n")
+	sb.WriteString(`    <Principal id="Author">` + "\r\n")
+	fmt.Fprintf(&sb, "      <UserId>%s</UserId>\r\n", xmlEscape(userID))
+	sb.WriteString("      <LogonType>InteractiveToken</LogonType>\r\n")
+	sb.WriteString("      <RunLevel>LeastPrivilege</RunLevel>\r\n")
+	sb.WriteString("    </Principal>\r\n")
+	sb.WriteString("  </Principals>\r\n")
+	sb.WriteString("  <Settings>\r\n")
+	sb.WriteString("    <MultipleInstancesPolicy>IgnoreNew</MultipleInstancesPolicy>\r\n")
+	sb.WriteString("    <DisallowStartIfOnBatteries>false</DisallowStartIfOnBatteries>\r\n")
+	sb.WriteString("    <StopIfGoingOnBatteries>false</StopIfGoingOnBatteries>\r\n")
+	sb.WriteString("    <AllowHardTerminate>true</AllowHardTerminate>\r\n")
+	sb.WriteString("    <StartWhenAvailable>true</StartWhenAvailable>\r\n")
+	sb.WriteString("    <RunOnlyIfNetworkAvailable>false</RunOnlyIfNetworkAvailable>\r\n")
+	sb.WriteString("    <IdleSettings>\r\n")
+	sb.WriteString("      <StopOnIdleEnd>false</StopOnIdleEnd>\r\n")
+	sb.WriteString("      <RestartOnIdle>false</RestartOnIdle>\r\n")
+	sb.WriteString("    </IdleSettings>\r\n")
+	sb.WriteString("    <AllowStartOnDemand>true</AllowStartOnDemand>\r\n")
+	sb.WriteString("    <Enabled>true</Enabled>\r\n")
+	sb.WriteString("    <Hidden>false</Hidden>\r\n")
+	sb.WriteString("    <RunOnlyIfIdle>false</RunOnlyIfIdle>\r\n")
+	sb.WriteString("    <WakeToRun>false</WakeToRun>\r\n")
+	sb.WriteString("    <ExecutionTimeLimit>PT0S</ExecutionTimeLimit>\r\n")
+	sb.WriteString("    <Priority>7</Priority>\r\n")
+	sb.WriteString("    <RestartOnFailure>\r\n")
+	sb.WriteString("      <Interval>PT1M</Interval>\r\n")
+	sb.WriteString("      <Count>9999</Count>\r\n")
+	sb.WriteString("    </RestartOnFailure>\r\n")
+	sb.WriteString("  </Settings>\r\n")
+	sb.WriteString(`  <Actions Context="Author">` + "\r\n")
+	sb.WriteString("    <Exec>\r\n")
+	sb.WriteString("      <Command>wscript.exe</Command>\r\n")
+	fmt.Fprintf(&sb, "      <Arguments>%s</Arguments>\r\n", xmlEscape(`"`+m.launcherPath()+`"`))
+	sb.WriteString("    </Exec>\r\n")
+	sb.WriteString("  </Actions>\r\n")
+	sb.WriteString("</Task>\r\n")
+	return sb.String(), nil
+}
+
+func runSchtasks(args ...string) (string, error) {
+	cmd := exec.Command("schtasks", args...)
+	out, err := cmd.CombinedOutput()
+	return strings.TrimSpace(string(out)), err
+}
+
+func runPowerShell(script string) (string, error) {
+	cmd := exec.Command("powershell", "-NoProfile", "-NonInteractive", "-Command", script)
+	out, err := cmd.CombinedOutput()
+	return strings.TrimSpace(string(out)), err
+}
+
+// vbsString renders a Go string as a VBScript double-quoted literal, doubling any
+// embedded quotes per VBScript escaping rules.
+func vbsString(s string) string {
+	return `"` + strings.ReplaceAll(s, `"`, `""`) + `"`
+}
+
+// powershellSingleQuote renders a value as a PowerShell single-quoted literal,
+// doubling embedded single quotes.
+func powershellSingleQuote(s string) string {
+	return "'" + strings.ReplaceAll(s, "'", "''") + "'"
+}
+
+// xmlEscape mirrors the helper used by the macOS plist builder.
+func xmlEscape(s string) string {
+	r := strings.NewReplacer("&", "&amp;", "<", "&lt;", ">", "&gt;", `"`, "&quot;", "'", "&apos;")
+	return r.Replace(s)
+}
+
+// encodeUTF16LE encodes text as UTF-16 little-endian with a BOM, the format
+// schtasks /Create /XML expects.
+func encodeUTF16LE(s string) []byte {
+	units := utf16.Encode([]rune(s))
+	buf := make([]byte, 0, 2+len(units)*2)
+	buf = append(buf, 0xFF, 0xFE) // little-endian BOM
+	for _, u := range units {
+		buf = append(buf, byte(u), byte(u>>8))
+	}
+	return buf
+}
+
+// EnableLingerCurrentUser is a no-op on Windows. The scheduled task starts at
+// logon and is managed by Task Scheduler; there is no systemd-style linger, and a
+// no-admin task intentionally runs only within the user's logon session.
+func EnableLingerCurrentUser() error {
+	return nil
+}

--- a/internal/daemon/schtasks_windows_test.go
+++ b/internal/daemon/schtasks_windows_test.go
@@ -1,0 +1,101 @@
+//go:build windows
+
+package daemon
+
+import (
+	"strings"
+	"testing"
+	"unicode/utf16"
+)
+
+func TestVBSString(t *testing.T) {
+	if got, want := vbsString(`a "b" c`), `"a ""b"" c"`; got != want {
+		t.Fatalf("vbsString = %q, want %q", got, want)
+	}
+}
+
+func TestPowershellSingleQuote(t *testing.T) {
+	if got, want := powershellSingleQuote("o'brien"), "'o''brien'"; got != want {
+		t.Fatalf("powershellSingleQuote = %q, want %q", got, want)
+	}
+}
+
+func TestEncodeUTF16LE(t *testing.T) {
+	b := encodeUTF16LE("AB")
+	want := []byte{0xFF, 0xFE, 'A', 0x00, 'B', 0x00}
+	if len(b) != len(want) {
+		t.Fatalf("encodeUTF16LE len = %d, want %d", len(b), len(want))
+	}
+	for i := range want {
+		if b[i] != want[i] {
+			t.Fatalf("encodeUTF16LE[%d] = %#x, want %#x", i, b[i], want[i])
+		}
+	}
+	// Round-trips back to the original text (excluding BOM).
+	units := make([]uint16, 0, (len(b)-2)/2)
+	for i := 2; i+1 < len(b); i += 2 {
+		units = append(units, uint16(b[i])|uint16(b[i+1])<<8)
+	}
+	if got := string(utf16.Decode(units)); got != "AB" {
+		t.Fatalf("round-trip = %q, want %q", got, "AB")
+	}
+}
+
+func TestBuildLauncherVBSHidesWindowAndPropagatesExit(t *testing.T) {
+	mgr := &schtasksManager{serviceName: DefaultServiceName}
+	vbs := mgr.buildLauncherVBS(Config{
+		BinaryPath: `C:\Program Files\feidex\feidex.exe`,
+		ConfigPath: `C:\Users\tester\config.toml`,
+	})
+	for _, want := range []string{
+		"WScript.Quit sh.Run(", // exit code propagates -> restart-on-failure
+		", 0, True)",           // window style 0 = hidden, wait for the daemon
+		`""C:\Program Files\feidex\feidex.exe"" serve --config`,
+		"2>&1",
+	} {
+		if !strings.Contains(vbs, want) {
+			t.Fatalf("launcher missing %q:\n%s", want, vbs)
+		}
+	}
+}
+
+func TestBuildTaskXMLContent(t *testing.T) {
+	mgr := &schtasksManager{serviceName: DefaultServiceName}
+	xml, err := mgr.buildTaskXML()
+	if err != nil {
+		t.Fatalf("buildTaskXML error = %v", err)
+	}
+	for _, want := range []string{
+		`<Task version="1.2"`,
+		"<LogonTrigger>",
+		"<LogonType>InteractiveToken</LogonType>", // no stored password, runs in user session
+		"<RunLevel>LeastPrivilege</RunLevel>",     // no admin
+		"<ExecutionTimeLimit>PT0S</ExecutionTimeLimit>",
+		"<RestartOnFailure>",
+		"<Command>wscript.exe</Command>", // windowless launcher host
+		"-launch.vbs",
+	} {
+		if !strings.Contains(xml, want) {
+			t.Fatalf("task xml missing %q:\n%s", want, xml)
+		}
+	}
+}
+
+func TestNewPlatformManagerWindows(t *testing.T) {
+	mgr, err := newPlatformManager(DefaultServiceName)
+	if err != nil {
+		t.Fatalf("newPlatformManager error = %v", err)
+	}
+	if mgr.Platform() != "Task Scheduler (Windows)" {
+		t.Fatalf("Platform = %q", mgr.Platform())
+	}
+	if mgr.LogFile() == "" {
+		t.Fatal("LogFile should be non-empty on Windows")
+	}
+}
+
+func TestEnableLingerNoopOnWindows(t *testing.T) {
+	if err := EnableLingerCurrentUser(); err != nil {
+		t.Fatalf("EnableLingerCurrentUser on windows = %v, want nil", err)
+	}
+}

--- a/internal/daemon/unsupported.go
+++ b/internal/daemon/unsupported.go
@@ -1,4 +1,4 @@
-//go:build !linux && !darwin
+//go:build !linux && !darwin && !windows
 
 package daemon
 


### PR DESCRIPTION
## What

Adds Windows support for `feidex daemon`, which previously worked only on Linux (user systemd) and macOS (per-user LaunchAgent). Implements the existing `daemon.Manager` interface for `//go:build windows`, so the same `install` / `start` / `stop` / `restart` / `status` / `logs` / `uninstall` commands work unchanged.

## Why Task Scheduler

The hard requirement is **no administrator privileges**. A per-user Windows Scheduled Task is the only option that still gives logon-start + auto-restart + lifecycle management:

- Windows service (`sc create` / NSSM) → requires elevation. ❌
- Registry `Run` key → auto-starts but has no keepalive / status / stop. Too weak. ❌
- **Per-user scheduled task → no elevation, no password.** ✅

## Design

- **At-logon trigger**, `InteractiveToken` principal, `LeastPrivilege` run level → no UAC, no stored credentials.
- **No console-window flash**: the task action runs a generated windowless VBScript through `wscript.exe`, which launches `feidex serve` hidden and waits on it, propagating the exit code so `RestartOnFailure` can restart on crash.
- **Language-neutral status**: running state comes from PowerShell `Get-ScheduledTask .State` (a culture-invariant enum) rather than the localized text `schtasks /Query` prints.
- Task XML is emitted as **UTF-16LE + BOM**, as `schtasks /Create /XML` requires.
- **Scope = login session**, matching the macOS LaunchAgent: runs while the user is logged on, stops at sign-out. Surviving logout would need a service or a stored password (privilege/password cost), so it is intentionally out of scope. `EnableLingerCurrentUser` is a no-op on Windows.

## Also included

- `cmd/feidex`: a built-in tail fallback for `daemon logs` on Windows (no `tail` binary); Unix keeps using system `tail`.
- `unsupported.go`: excluded from the `windows` build.
- Docs: new Windows daemon section in `docs/operations.md`; corrected `README.md` / `install.ps1` notes that claimed the daemon was Linux/macOS only. `/upgrade` self-upgrade remains Linux-only.

## Verification

On Windows 11 with a **non-elevated** user account:

- `daemon install` → scheduled task registered and `Running` (Run As User = current user, Logon Mode = Interactive only), no UAC prompt
- `daemon status` → reports Running via the PowerShell state read
- `daemon uninstall` → task deleted, generated files removed, status back to Not installed

Plus: `go build ./...`, Windows `amd64` + `arm64` cross-builds, and `go test ./internal/daemon/ ./cmd/feidex/` all pass; new tests cover the VBScript/XML/UTF-16/quoting helpers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)